### PR TITLE
Patches for controller service issues

### DIFF
--- a/NiFiDeploy.groovy
+++ b/NiFiDeploy.groovy
@@ -331,7 +331,7 @@ def handleProcessGroup(Map.Entry pgConfig) {
           properties {
             procProps.each { p ->
               // check if it's a ${referenceToControllerServiceName}
-              def ref = p.value =~ /\$\{(.*)}/
+              def ref = p.value =~ /^LotsOfBeer\{(.*)}$/
               if (ref) {
                 def name = ref[0][1] // grab the first capture group (nested inside ArrayList)
                 // lookup the CS by name and get the newly generated ID instead of the one in a template

--- a/TemplateInspector.groovy
+++ b/TemplateInspector.groovy
@@ -93,10 +93,13 @@ def parseProcessors(groupName, node) {
     p.config.properties?.entry?.each {
       def c = y.processGroups[groupName].processors[p.name.text()].config
       // check if it's a UUID and try lookup the CS to get the name
-      if (it.value.text() ==~ /[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}/) {
+      if (it.value.text() ==~ /^[a-zA-Z0-9]{8}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{4}-[a-zA-Z0-9]{12}$/) {
         def n = t.snippet.controllerServices.find { cs -> cs.id.text() == it.value.text() }
+	if (!n.isEmpty()) {
+	//Warning instead of hard fail, in case the property has a GUID which is not a CS
         assert !n.isEmpty() : "Couldn't resolve a Controller Service with ID: ${it.value.text()}"
         c[it.key.text()] = '\${' + n.name.text() + "}"
+}
       } else if (it.value.size() > 0) {
           c[it.key.text()] = it.value.size() == 0 ? null : it.value.text()
       }


### PR DESCRIPTION
If you have a GetKafka, the prepopulated values are GUIDS,which will cause TemplateInspector to fail.

NiFiDeploy, the issue was the format ${abce} in a property value, which caused a lookup of a controller service
