### PR TITLE
updated YAML template and deploy scripts to match the NiFi 1.0.0 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,13 @@ nifi:
   # Tell NiFi we want some things removed to make way for this (re-) deployment
   undeploy:
 
-    # Names of controller services to remove. Ignores any missing ones
-    controllerServices:
-      - StandardHttpContextMap
-      - SomeOtherControllerService
-
     # Names of process groups to remove. These are in your template
     processGroups:
-      - Hello NiFi Web Service
+      Hello NiFi Web Service:
+        # Names of controller services to remove. Ignores any missing ones
+        controllerServices:
+          - StandardHttpContextMap
+          - SomeOtherControllerService
 
     # Template names to remove. Because we're updating with a new version
     templates:
@@ -82,10 +81,6 @@ nifi:
 
 Next, one describes what configuration changes need to be applied to the template in this deployment:
 ```
-# Instantiate these controller services, our template uses them
-controllerServices:
-  StandardHttpContextMap:
-    state: ENABLED
 
 # Processors belong to process groups.
 # This way random ones won't be picked up (unlike a search api,
@@ -113,6 +108,10 @@ processGroups:
       "Update Request Body with a greeting!":
         config:
           Replacement Value: Dynamically Configured NiFi!
+    # Instantiate these controller services, our template uses them
+    controllerServices:
+      StandardHttpContextMap:
+        state: ENABLED
 
 ```
 

--- a/nifi-deploy.yml
+++ b/nifi-deploy.yml
@@ -1,22 +1,16 @@
 nifi:
-  url: http://192.168.99.103:9091
+  url: http://127.0.0.1:8080
   clientId: Deployment Script v1
   templateUri: "https://cwiki.apache.org/confluence/download/attachments/57904847/Hello_NiFi_Web_Service.xml?version=1&modificationDate=1449369797000&api=v2"
   # templateUri: file:./Hello_nifi.xml
   undeploy:
-    controllerServices:
-      - StandardHttpContextMap
-      - SomeOtherControllerService
     processGroups:
-      - Hello NiFi Web Service
+      Hello NiFi Web Service:
+        controllerServices:
+          - StandardHttpContextMap
+          - SomeOtherControllerService
     templates:
       - Hello NiFi Web Service
-
-controllerServices:
-  StandardHttpContextMap:
-    state: ENABLED
-    config:
-      Maximum Outstanding Requests: 20
 
 processGroups:
   root: ~
@@ -31,3 +25,8 @@ processGroups:
       "Update Request Body with a greeting!":
         config:
           Replacement Value: Dynamically Configured NiFi!
+    controllerServices:
+      StandardHttpContextMap:
+        state: ENABLED
+        config:
+          Maximum Outstanding Requests: 20


### PR DESCRIPTION
this fixes #32 

Overall I think the approach needs to walk away from Groovy and wrap the API calls formally against an SDK (java, python, whichever). 
Additionally, the NiFi API in 1.0 has tremendously changed and brought a new construct as controller services are now linked to process groups. This also brought a bug as outlined here: 
https://issues.apache.org/jira/browse/NIFI-2895?jql=project%20%3D%20NIFI

As long as this is not resolved the script will work but things may break. 
